### PR TITLE
pause does an entire screen splash

### DIFF
--- a/DataVille/game/screens.rpy
+++ b/DataVille/game/screens.rpy
@@ -306,6 +306,15 @@ style quick_button_text:
 
 
 screen navigation():
+    if not main_menu:
+        add "tv_noise":
+            pos (700, 145)
+            xoffset 0
+            yoffset 0
+            zoom 1.1
+            at VHS
+        add "tv_hollow"
+    
     vbox:
         style_prefix "navigation"
 

--- a/DataVille/game/script.rpy
+++ b/DataVille/game/script.rpy
@@ -537,6 +537,3 @@ label start:
 
       jump start
       #return
-
-
-


### PR DESCRIPTION
So there's no real way to fix this without completely rewriting how we do screens in our scripts and layers, handling screen variables and transforms, and just a massive headache. 

So I'm putting a big bandaid on this. When you pause the game, the screen that's used when you start the game will fade in, but only the static, no cycling of images.

Now we don't have to worry what's hiding on what layer or whatever when you pause the game.